### PR TITLE
Fix test.cpp build

### DIFF
--- a/srt_url_parser.cpp
+++ b/srt_url_parser.cpp
@@ -1,6 +1,10 @@
 #include <sstream>
 #include <algorithm>
 #include <cctype>
+#include <vector>
+#include <string>
+#include <cstdio>
+#include "srt_url_parser.h"
 
 // ===========================================
 // 内部辅助类：SRT URL解析器

--- a/test.cpp
+++ b/test.cpp
@@ -1,6 +1,11 @@
 // ===========================================
 // 测试和使用示例
 // ===========================================
+#include <cstdio>
+#include <cstddef>
+#include <string>
+#include <vector>
+#include "srt_url_parser.h"
 void test_parse_srt_url() {
   printf("=== SRT URL解析测试 ===\n\n");
   


### PR DESCRIPTION
## Summary
- add missing headers for test.cpp and srt_url_parser.cpp

## Testing
- `g++ -std=c++11 test.cpp srt_url_parser.cpp -o test.out && ./test.out | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684e6627d2848320aff38f941ded1063