### PR TITLE
Fix host validator compilation and improve test UI

### DIFF
--- a/host_test.cpp
+++ b/host_test.cpp
@@ -84,6 +84,7 @@ int main() {
         getline(cin, input);
         
         if (input == "quit") {
+            cout << "退出" << endl;
             break;
         }
         

--- a/host_validator.cpp
+++ b/host_validator.cpp
@@ -1,3 +1,12 @@
+#include <string>
+#include <vector>
+#include <regex>
+#include <sstream>
+#include <cctype>
+#include "host_validator.h"
+
+using namespace std;
+
 class HostValidator {
 private:
     // 危险字符列表，用于防止注入攻击


### PR DESCRIPTION
## Summary
- add missing includes and `using namespace std` to host_validator.cpp
- print a message on exit in host_test.cpp

## Testing
- `g++ -std=c++11 host_test.cpp host_validator.cpp -o host_test`
- `./host_test <<EOF
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684fb702ee308320948cfc73306f739c