### PR TITLE
Simplify IPv4 parsing

### DIFF
--- a/host_validator.cpp
+++ b/host_validator.cpp
@@ -3,6 +3,7 @@
 #include <regex>
 #include <sstream>
 #include <cctype>
+#include <cstdlib>
 #include "host_validator.h"
 
 using namespace std;
@@ -125,12 +126,9 @@ public:
             if (oct.length() > 3) return false;
             
             // 转换为数字并检查范围
-            try {
-                int num = stoi(oct);
-                if (num < 0 || num > 255) {
-                    return false;
-                }
-            } catch (...) {
+            char* endptr = nullptr;
+            long num = strtol(oct.c_str(), &endptr, 10);
+            if (*endptr != '\0' || num < 0 || num > 255) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- simplify the IPv4 validator implementation
  - switch to `strtol` for conversion
  - add `<cstdlib>` include for `strtol`

## Testing
- `g++ -std=c++11 host_test.cpp host_validator.cpp -o host_test.out`
- `echo quit | ./host_test.out | tail -n 7`

------
https://chatgpt.com/codex/tasks/task_e_685f8f36d38883208925d9c798a0321a